### PR TITLE
driver fixes, tooling improvements, and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ Note, this will take sometime to build.
 cd ADCAM/sdcard-images-utils/rpi
 ./setup.sh
 ./runme.sh 7.0.0-a.1 rel-7.0.0-a.1
-cd NVIDIA_ToF_ADSD3500_REL_PATCH_08Apr26
+unzip RPI_ToF_ADSD3500_REL_PATCH_08Apr26.zip
+cd RPI_ToF_ADSD3500_REL_PATCH_08Apr26
 sudo ./apply_patch.sh
 sudo reboot
 ```

--- a/sdcard-images-utils/README.md
+++ b/sdcard-images-utils/README.md
@@ -4,3 +4,4 @@
 | Directory | Description |
 | --------- | ----------- |
 | nvidia | Utilities required to create collateral for the NVIDIA Jetson Orin Nano Dev Kit |
+| rpi    | Utilities required to create collateral for the Raspberry Pi 5 Model 8GB RAM    |

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0025-media-i2c-nv_adsd3500-Fix-RAW8-Bayer-format-and-inte.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0025-media-i2c-nv_adsd3500-Fix-RAW8-Bayer-format-and-inte.patch
@@ -1,0 +1,60 @@
+From 0d90c0ff4940adc19932cb3148be457712d3b1ce Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 13 Apr 2026 14:26:03 +0530
+Subject: [PATCH] media: i2c: nv_adsd3500: Fix RAW8 Bayer format and interrupt
+ handling
+
+Correct the RAW8 media bus format from SBGGR8 to SRGGB8 in the
+mode table, and ensure interrupt configuration is performed for
+both PWM and non-PWM configuration.
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/nv_adsd3500.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index 68d4c4ab..ba349e4f 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -242,20 +242,20 @@ static irqreturn_t adsd3500_irq_handler(int irq,void *priv)
+ /* Elements of the structure must be ordered ascending by width & height */
+ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 
+-	/* --- RAW 8 MEDIA_BUS_FMT_SBGGR8_1X8 --- */
++	/* --- RAW 8 MEDIA_BUS_FMT_SRGGB8_1X8 --- */
+ 
+ 	{	/* RAW8 8BPP ADSD3100 QMP RESOLUTION */
+ 		.width = 512,
+ 		.height = 512,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+ 	{	/* RAW8 16BPP ADSD3100 QMP RESOLUTION */
+ 		.width = 1024,
+ 		.height = 512,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+ 	{       /* RAW8 16BPP Phase 12BPP AB ADSD3100 - DUAL MP - (1024x1 1024x4) */
+@@ -1843,6 +1843,13 @@ static int adsd3500_probe(struct i2c_client *client,
+ 		if(ret < 0)
+ 			dev_err(&client->dev, "Failed to initalize interrupt\n");
+ 	}
++	else {
++		ret = adsd3500_configure_interrupt(priv);
++		if (ret < 0)
++			dev_err(&client->dev, "Failed to initalize interrupt\n");
++	}
++
++
+ 
+ 	priv->sd->internal_ops = &adsd3500_subdev_internal_ops;
+ 	priv->sd->flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode0.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode0.sh
@@ -22,4 +22,4 @@ v4l2-ctl --set-ctrl=ab_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=confidence_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=ab_averaging=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=depth_enable=0 -d $SUBDEV_PATH
-v4l2-ctl --device /dev/video0 --set-fmt-video=width=2048,height=3072,pixelformat=RG12 --stream-mmap --stream-to=raw_mode0.bin --stream-count=$nr_frames
+v4l2-ctl --device $VIDEO_PATH --set-fmt-video=width=2048,height=3072,pixelformat=RG12 --stream-mmap --stream-to=raw_mode0.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode1.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode1.sh
@@ -22,4 +22,4 @@ v4l2-ctl --set-ctrl=ab_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=confidence_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=ab_averaging=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=depth_enable=0 -d $SUBDEV_PATH
-v4l2-ctl --device /dev/video0 --set-fmt-video=width=2048,height=4608,pixelformat=RG12 --stream-mmap --stream-to=raw_mode1.bin --stream-count=$nr_frames
+v4l2-ctl --device $VIDEO_PATH --set-fmt-video=width=2048,height=4608,pixelformat=RG12 --stream-mmap --stream-to=raw_mode1.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode2.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode2.sh
@@ -22,4 +22,4 @@ v4l2-ctl --set-ctrl=ab_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=confidence_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=ab_averaging=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=depth_enable=0 -d $SUBDEV_PATH
-v4l2-ctl --device /dev/video0 --set-fmt-video=width=1024,height=1536,pixelformat=RG12 --stream-mmap --stream-to=raw_mode2.bin --stream-count=$nr_frames
+v4l2-ctl --device $VIDEO_PATH --set-fmt-video=width=1024,height=1536,pixelformat=RG12 --stream-mmap --stream-to=raw_mode2.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode3.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode3.sh
@@ -22,4 +22,4 @@ v4l2-ctl --set-ctrl=ab_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=confidence_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=ab_averaging=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=depth_enable=0 -d $SUBDEV_PATH
-v4l2-ctl --device /dev/video0 --set-fmt-video=width=1024,height=2304,pixelformat=RG12 --stream-mmap --stream-to=raw_mode3.bin --stream-count=$nr_frames
+v4l2-ctl --device $VIDEO_PATH --set-fmt-video=width=1024,height=2304,pixelformat=RG12 --stream-mmap --stream-to=raw_mode3.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode5.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode5.sh
@@ -22,4 +22,4 @@ v4l2-ctl --set-ctrl=ab_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=confidence_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=ab_averaging=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=depth_enable=0 -d $SUBDEV_PATH
-v4l2-ctl --device /dev/video0 --set-fmt-video=width=1024,height=2304,pixelformat=RG12 --stream-mmap --stream-to=raw_mode5.bin --stream-count=$nr_frames
+v4l2-ctl --device $VIDEO_PATH --set-fmt-video=width=1024,height=2304,pixelformat=RG12 --stream-mmap --stream-to=raw_mode5.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode6.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3175DUAL/raw/get_raw_frame_RAW12_ADTF3175D_mode6.sh
@@ -22,4 +22,4 @@ v4l2-ctl --set-ctrl=ab_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=confidence_bits=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=ab_averaging=0 -d $SUBDEV_PATH
 v4l2-ctl --set-ctrl=depth_enable=0 -d $SUBDEV_PATH
-v4l2-ctl --device /dev/video0 --set-fmt-video=width=1024,height=1536,pixelformat=RG12 --stream-mmap --stream-to=raw_mode6.bin --stream-count=$nr_frames
+v4l2-ctl --device $VIDEO_PATH --set-fmt-video=width=1024,height=1536,pixelformat=RG12 --stream-mmap --stream-to=raw_mode6.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/runme.sh
+++ b/sdcard-images-utils/nvidia/runme.sh
@@ -664,6 +664,16 @@ create_package() {
         log_warning "apply_patch.sh not found at ${apply_script}"
     fi
 
+    # Copy patch_validation.sh script
+    local validation_script="${ROOTDIR}/scripts/system_upgrade/patch_validation.sh"
+    if [[ -f "${validation_script}" ]]; then
+        cp "${validation_script}" "${PATCH_DIR}/" || log_warning "Failed to copy patch_validation.sh"
+        log_info "Copied: patch_validation.sh"
+    else
+        log_warning "patch_validation.sh not found at ${validation_script}"
+    fi
+
+
     local archive_name="NVIDIA_ToF_ADSD3500_REL_PATCH_$(date +"%d%b%y").zip"
     local patch_dir_name=$(basename "${PATCH_DIR}")
 

--- a/sdcard-images-utils/rpi/patches/linux/0026-drivers-media-i2c-adsd3500-Configure-interrupt-in-no.patch
+++ b/sdcard-images-utils/rpi/patches/linux/0026-drivers-media-i2c-adsd3500-Configure-interrupt-in-no.patch
@@ -1,0 +1,48 @@
+From 964726ee9ba20910f97e3a0b8f076bfe7e8b4514 Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 13 Apr 2026 16:47:34 +0530
+Subject: [PATCH] drivers: media: i2c: adsd3500: Configure interrupt in non-PWM
+ probe path
+
+Ensure adsd3500_configure_interrupt() is invoked when no PWM is
+provided, so interrupt setup is consistent across probe paths.
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500.c      | 6 ++++++
+ drivers/media/i2c/adsd3500_regs.h | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index e426041d7f52..0de0d8d6b179 100755
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -1926,6 +1926,12 @@ static int adsd3500_probe(struct i2c_client *client)
+ 		if(ret < 0)
+ 			dev_err(&client->dev, "Failed to initalize interrupt\n");
+ 	}
++	else {
++		ret = adsd3500_configure_interrupt(adsd3500);
++		if(ret < 0){
++			dev_err(&client->dev, "Failed to initalize interrupt\n");
++		}
++	}
+ 
+ 	memset(&adsd3500->fmt, 0, sizeof(adsd3500->fmt));
+ 	adsd3500->fmt.width  = adsd3500_mode_info_data[0].width;
+diff --git a/drivers/media/i2c/adsd3500_regs.h b/drivers/media/i2c/adsd3500_regs.h
+index 941a4c63b84a..630c64cd0eb6 100755
+--- a/drivers/media/i2c/adsd3500_regs.h
++++ b/drivers/media/i2c/adsd3500_regs.h
+@@ -11,7 +11,7 @@
+ 
+ #include <linux/bitfield.h>
+ 
+-#define DRIVER_VERSION                          "6.3.0"
++#define DRIVER_VERSION                          "7.0.0"
+ 
+ #define GET_CHIP_ID_CMD				0x0112
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
1. Media driver fixes to correct RAW8 Bayer format handling and ensure interrupt configuration is performed consistently, including probe paths where no IRQ is provided.
2. Kernel driver robustness improvements by invoking interrupt setup in both IRQ and non‑IRQ scenarios, preventing incomplete initialization during device bring‑up.
3. Tooling enhancements to improve usability and validation:
        Removal of hard‑coded video device nodes in capture scripts in favor of configurable paths.
        Inclusion of a patch_validation.sh script in generated release packages to support post‑patch verification. 
4. Documentation updates to clarify Raspberry Pi 5 patch application steps and to document newly added RPi utilities alongside existing NVIDIA tooling.