### PR TITLE
add processed RAW8 frame capture scripts for ADTF3066

### DIFF
--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode0.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode0.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MEDIA_DEVICE="/dev/media0"
+DOT_OUTPUT=$(media-ctl -d "$MEDIA_DEVICE" --print-dot)
+DOT_OUTPUT=$(echo "$DOT_OUTPUT" | sed 's/\\n/\n/g')
+SUBDEV_PATH=$(echo "$DOT_OUTPUT" | awk '/adsd3500/ {getline; if ($0 ~ /\/dev\/v4l-subdev/) print $1}' | tr -d '","')
+VIDEO_PATH=$(echo "$DOT_OUTPUT" | awk '/vi-output, adsd3500/ {getline; if ($0 ~ /\/dev\/video/) print $1}' | tr -d '","')
+
+if [[ -n "$SUBDEV_PATH" && -n "$VIDEO_PATH" ]]; then
+    echo "adsd3500 subdev: $SUBDEV_PATH" > /dev/null
+    echo "adsd3500 video : $VIDEO_PATH"  > /dev/null
+else
+    echo "adsd3500 device not found in $MEDIA_DEVICE"
+    exit 1
+fi
+
+nr_frames=${1:-1}
+
+v4l2-ctl --set-ctrl=operating_mode=0 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=phase_depth_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=confidence_bits=2 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_averaging=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=depth_enable=1 -d /dev/v4l-subdev1
+v4l2-ctl --device /dev/video0 --set-fmt-video=width=2560,height=640,pixelformat=RGGB --stream-mmap --stream-to=mode0.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode1.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode1.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MEDIA_DEVICE="/dev/media0"
+DOT_OUTPUT=$(media-ctl -d "$MEDIA_DEVICE" --print-dot)
+DOT_OUTPUT=$(echo "$DOT_OUTPUT" | sed 's/\\n/\n/g')
+SUBDEV_PATH=$(echo "$DOT_OUTPUT" | awk '/adsd3500/ {getline; if ($0 ~ /\/dev\/v4l-subdev/) print $1}' | tr -d '","')
+VIDEO_PATH=$(echo "$DOT_OUTPUT" | awk '/vi-output, adsd3500/ {getline; if ($0 ~ /\/dev\/video/) print $1}' | tr -d '","')
+
+if [[ -n "$SUBDEV_PATH" && -n "$VIDEO_PATH" ]]; then
+    echo "adsd3500 subdev: $SUBDEV_PATH" > /dev/null
+    echo "adsd3500 video : $VIDEO_PATH"  > /dev/null
+else
+    echo "adsd3500 device not found in $MEDIA_DEVICE"
+    exit 1
+fi
+
+nr_frames=${1:-1}
+
+v4l2-ctl --set-ctrl=operating_mode=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=phase_depth_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=confidence_bits=2 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_averaging=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=depth_enable=1 -d /dev/v4l-subdev1
+v4l2-ctl --device /dev/video0 --set-fmt-video=width=2560,height=640,pixelformat=RGGB --stream-mmap --stream-to=mode1.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode3.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode3.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MEDIA_DEVICE="/dev/media0"
+DOT_OUTPUT=$(media-ctl -d "$MEDIA_DEVICE" --print-dot)
+DOT_OUTPUT=$(echo "$DOT_OUTPUT" | sed 's/\\n/\n/g')
+SUBDEV_PATH=$(echo "$DOT_OUTPUT" | awk '/adsd3500/ {getline; if ($0 ~ /\/dev\/v4l-subdev/) print $1}' | tr -d '","')
+VIDEO_PATH=$(echo "$DOT_OUTPUT" | awk '/vi-output, adsd3500/ {getline; if ($0 ~ /\/dev\/video/) print $1}' | tr -d '","')
+
+if [[ -n "$SUBDEV_PATH" && -n "$VIDEO_PATH" ]]; then
+    echo "adsd3500 subdev: $SUBDEV_PATH" > /dev/null
+    echo "adsd3500 video : $VIDEO_PATH"  > /dev/null
+else
+    echo "adsd3500 device not found in $MEDIA_DEVICE"
+    exit 1
+fi
+
+nr_frames=${1:-1}
+
+v4l2-ctl --set-ctrl=operating_mode=3 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=phase_depth_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=confidence_bits=2 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_averaging=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=depth_enable=1 -d /dev/v4l-subdev1
+v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=320,pixelformat=RGGB --stream-mmap --stream-to=mode3.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode6.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode6.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MEDIA_DEVICE="/dev/media0"
+DOT_OUTPUT=$(media-ctl -d "$MEDIA_DEVICE" --print-dot)
+DOT_OUTPUT=$(echo "$DOT_OUTPUT" | sed 's/\\n/\n/g')
+SUBDEV_PATH=$(echo "$DOT_OUTPUT" | awk '/adsd3500/ {getline; if ($0 ~ /\/dev\/v4l-subdev/) print $1}' | tr -d '","')
+VIDEO_PATH=$(echo "$DOT_OUTPUT" | awk '/vi-output, adsd3500/ {getline; if ($0 ~ /\/dev\/video/) print $1}' | tr -d '","')
+
+if [[ -n "$SUBDEV_PATH" && -n "$VIDEO_PATH" ]]; then
+    echo "adsd3500 subdev: $SUBDEV_PATH" > /dev/null
+    echo "adsd3500 video : $VIDEO_PATH"  > /dev/null
+else
+    echo "adsd3500 device not found in $MEDIA_DEVICE"
+    exit 1
+fi
+
+nr_frames=${1:-1}
+
+v4l2-ctl --set-ctrl=operating_mode=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=phase_depth_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=confidence_bits=2 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_averaging=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=depth_enable=1 -d /dev/v4l-subdev1
+v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=320,pixelformat=RGGB --stream-mmap --stream-to=mode6.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode7.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode7.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MEDIA_DEVICE="/dev/media0"
+DOT_OUTPUT=$(media-ctl -d "$MEDIA_DEVICE" --print-dot)
+DOT_OUTPUT=$(echo "$DOT_OUTPUT" | sed 's/\\n/\n/g')
+SUBDEV_PATH=$(echo "$DOT_OUTPUT" | awk '/adsd3500/ {getline; if ($0 ~ /\/dev\/v4l-subdev/) print $1}' | tr -d '","')
+VIDEO_PATH=$(echo "$DOT_OUTPUT" | awk '/vi-output, adsd3500/ {getline; if ($0 ~ /\/dev\/video/) print $1}' | tr -d '","')
+
+if [[ -n "$SUBDEV_PATH" && -n "$VIDEO_PATH" ]]; then
+    echo "adsd3500 subdev: $SUBDEV_PATH" > /dev/null
+    echo "adsd3500 video : $VIDEO_PATH"  > /dev/null
+else
+    echo "adsd3500 device not found in $MEDIA_DEVICE"
+    exit 1
+fi
+
+nr_frames=${1:-1}
+
+v4l2-ctl --set-ctrl=operating_mode=7 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=phase_depth_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=confidence_bits=2 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_averaging=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=depth_enable=1 -d /dev/v4l-subdev1
+v4l2-ctl --device /dev/video0 --set-fmt-video=width=2560,height=640,pixelformat=RGGB --stream-mmap --stream-to=mode7.bin --stream-count=$nr_frames

--- a/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode8.sh
+++ b/sdcard-images-utils/nvidia/patches/ubuntu_overlay/Tools/adsd3500_get_frame/ADTF3066DUAL/processed/get_frame_RAW8_16D_16AB_8C_ADTF3066_mode8.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+MEDIA_DEVICE="/dev/media0"
+DOT_OUTPUT=$(media-ctl -d "$MEDIA_DEVICE" --print-dot)
+DOT_OUTPUT=$(echo "$DOT_OUTPUT" | sed 's/\\n/\n/g')
+SUBDEV_PATH=$(echo "$DOT_OUTPUT" | awk '/adsd3500/ {getline; if ($0 ~ /\/dev\/v4l-subdev/) print $1}' | tr -d '","')
+VIDEO_PATH=$(echo "$DOT_OUTPUT" | awk '/vi-output, adsd3500/ {getline; if ($0 ~ /\/dev\/video/) print $1}' | tr -d '","')
+
+if [[ -n "$SUBDEV_PATH" && -n "$VIDEO_PATH" ]]; then
+    echo "adsd3500 subdev: $SUBDEV_PATH" > /dev/null
+    echo "adsd3500 video : $VIDEO_PATH"  > /dev/null
+else
+    echo "adsd3500 device not found in $MEDIA_DEVICE"
+    exit 1
+fi
+
+nr_frames=${1:-1}
+
+v4l2-ctl --set-ctrl=operating_mode=8 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=phase_depth_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_bits=6 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=confidence_bits=2 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=ab_averaging=1 -d /dev/v4l-subdev1
+v4l2-ctl --set-ctrl=depth_enable=1 -d /dev/v4l-subdev1
+v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=320,pixelformat=RGGB --stream-mmap --stream-to=mode8.bin --stream-count=$nr_frames


### PR DESCRIPTION
Introduced mode‑specific RAW8 capture scripts for ADTF3066 DUAL under the processed/ directory.
Added scripts covering multiple operating modes (Mode 0, 1, 3, 6, 7, and 8) to ensure consistent capture workflows.
Ensured scripts are executable and aligned with existing ADCAM tooling conventions.