### PR TITLE
add RAW8 modes and increase sensor mode capacity

### DIFF
--- a/sdcard-images-utils/nvidia/patches/hardware/nvidia/t23x/nv-public/0022-overlay-adsd3500_dual-add-new-modes-for-RAW8-resolut.patch
+++ b/sdcard-images-utils/nvidia/patches/hardware/nvidia/t23x/nv-public/0022-overlay-adsd3500_dual-add-new-modes-for-RAW8-resolut.patch
@@ -1,0 +1,1296 @@
+From c41cec9adc6950b25fab9072eaca99e01b09b49d Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 18 May 2026 15:43:21 +0530
+Subject: [PATCH] overlay: adsd3500_dual: add new modes for RAW8 resolutions
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ .../tegra234-p3767-camera-p3768-adsd3500.dts  | 416 ++++++++++++++++++
+ ...-dual-adsd3500-adsd3100-arducam-ar0234.dts | 416 ++++++++++++++++++
+ ...67-camera-p3768-dual-adsd3500-adsd3100.dts | 416 ++++++++++++++++++
+ 3 files changed, 1248 insertions(+)
+
+diff --git a/overlay/tegra234-p3767-camera-p3768-adsd3500.dts b/overlay/tegra234-p3767-camera-p3768-adsd3500.dts
+index cf5ff82..225fcc8 100644
+--- a/overlay/tegra234-p3767-camera-p3768-adsd3500.dts
++++ b/overlay/tegra234-p3767-camera-p3768-adsd3500.dts
+@@ -2503,6 +2503,422 @@
+                                                         max_exp_time = "660000";
+                                                         embedded_metadata_height = "1";
+                                                 };
++						mode69 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1707";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode70 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1024";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode71 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1366";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode72 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "2048";
++							active_h = "1024";
++							readout_orientation = "0";
++							line_length = "2048";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode73 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1536";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode74 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "2048";
++							active_h = "1792";
++							readout_orientation = "0";
++							line_length = "2048";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode75 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "3584";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode76 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1536";
++							active_h = "854";
++							readout_orientation = "0";
++							line_length = "1536";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode77 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1536";
++							active_h = "683";
++							readout_orientation = "0";
++							line_length = "1536";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode78 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "768";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode79 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1536";
++							active_h = "768";
++							readout_orientation = "0";
++							line_length = "1536";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode80 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "896";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode81 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "512";
++							active_h = "1792";
++							readout_orientation = "0";
++							line_length = "512";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
+ 						ports {
+ 							#address-cells = <1>;
+ 							#size-cells = <0>;
+diff --git a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts
+index e510b3d..af5f098 100644
+--- a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts
++++ b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts
+@@ -2735,6 +2735,422 @@
+ 								max_exp_time = "660000";
+ 								embedded_metadata_height = "1";
+ 							};
++							mode69 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "3072";
++								active_h = "1707";
++								readout_orientation = "0";
++								line_length = "3072";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode70 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "3072";
++								active_h = "1024";
++								readout_orientation = "0";
++								line_length = "3072";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode71 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "3072";
++								active_h = "1366";
++								readout_orientation = "0";
++								line_length = "3072";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode72 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "2048";
++								active_h = "1024";
++								readout_orientation = "0";
++								line_length = "2048";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode73 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "3072";
++								active_h = "1536";
++								readout_orientation = "0";
++								line_length = "3072";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode74 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "2048";
++								active_h = "1792";
++								readout_orientation = "0";
++								line_length = "2048";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode75 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1024";
++								active_h = "3584";
++								readout_orientation = "0";
++								line_length = "1024";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode76 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1536";
++								active_h = "854";
++								readout_orientation = "0";
++								line_length = "1536";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode77 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1536";
++								active_h = "683";
++								readout_orientation = "0";
++								line_length = "1536";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode78 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1024";
++								active_h = "768";
++								readout_orientation = "0";
++								line_length = "1024";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode79 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1536";
++								active_h = "768";
++								readout_orientation = "0";
++								line_length = "1536";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode80 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1024";
++								active_h = "896";
++								readout_orientation = "0";
++								line_length = "1024";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
++							mode81 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "512";
++								active_h = "1792";
++								readout_orientation = "0";
++								line_length = "512";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
+ 							ports {
+ 								#address-cells = <1>;
+ 								#size-cells = <0>;
+diff --git a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+index 5e8ef94..dd1c0be 100644
+--- a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
++++ b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+@@ -2439,6 +2439,422 @@
+                                                         max_exp_time = "660000";
+                                                         embedded_metadata_height = "1";
+                                                 };
++						mode69 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1707";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode70 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1024";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode71 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1366";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode72 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "2048";
++							active_h = "1024";
++							readout_orientation = "0";
++							line_length = "2048";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode73 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "3072";
++							active_h = "1536";
++							readout_orientation = "0";
++							line_length = "3072";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode74 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "2048";
++							active_h = "1792";
++							readout_orientation = "0";
++							line_length = "2048";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode75 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "3584";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode76 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1536";
++							active_h = "854";
++							readout_orientation = "0";
++							line_length = "1536";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode77 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1536";
++							active_h = "683";
++							readout_orientation = "0";
++							line_length = "1536";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode78 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "768";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode79 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1536";
++							active_h = "768";
++							readout_orientation = "0";
++							line_length = "1536";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode80 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "896";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
++						mode81 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "512";
++							active_h = "1792";
++							readout_orientation = "0";
++							line_length = "512";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
+ 						ports {
+ 							#address-cells = <1>;
+ 							#size-cells = <0>;
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0026-include-media-tegra-increase-MAX_NUM_SENSOR_MODES-to.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0026-include-media-tegra-increase-MAX_NUM_SENSOR_MODES-to.patch
@@ -1,0 +1,32 @@
+From 16fcd6c547260ea822584438cab3149abf169ba2 Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 18 May 2026 14:48:44 +0530
+Subject: [PATCH] include: media: tegra: increase MAX_NUM_SENSOR_MODES to 120
+
+- Extend MAX_NUM_SENSOR_MODES from 90 to 120 to support sensors
+  exposing a larger set of operating modes.
+- Prevent potential truncation or failure when enumerating modes
+  in drivers with higher mode counts.
+- No functional change for existing sensors below the previous limit.
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ include/media/tegra-v4l2-camera.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/media/tegra-v4l2-camera.h b/include/media/tegra-v4l2-camera.h
+index 240a16d6..57997c1c 100644
+--- a/include/media/tegra-v4l2-camera.h
++++ b/include/media/tegra-v4l2-camera.h
+@@ -71,7 +71,7 @@
+ 
+ #define MAX_BUFFER_SIZE			32
+ #define MAX_CID_CONTROLS		32
+-#define MAX_NUM_SENSOR_MODES		90
++#define MAX_NUM_SENSOR_MODES		120
+ #define OF_MAX_STR_LEN			256
+ #define OF_SENSORMODE_PREFIX ("mode")
+ 
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0027-drivers-media-i2c-nv_adsd3500-add-RAW8-sensor-modes-.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0027-drivers-media-i2c-nv_adsd3500-add-RAW8-sensor-modes-.patch
@@ -1,0 +1,178 @@
+From 0eb9ad82a14eb5640a480ec4d5a3ac7ebe728f9d Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Wed, 20 May 2026 21:52:20 +0530
+Subject: [PATCH] drivers: media: i2c: nv_adsd3500: add RAW8 sensor modes
+ support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Introduce multiple RAW8 (MEDIA_BUS_FMT_SRGGB8_1X8) modes with new
+  resolutions and configurations in adsd3500_mode_tbls and mode info.
+- Extend enum and frame format tables to expose additional sensor
+  operating modes (modes 69–81) at 30 FPS.
+- Update mode info table with corresponding pixel rate and link
+  frequency entries to ensure proper pipeline configuration.
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500_mode_tbls.h | 30 ++++++++
+ drivers/media/i2c/nv_adsd3500.c        | 94 ++++++++++++++++++++++++++
+ 2 files changed, 124 insertions(+)
+
+diff --git a/drivers/media/i2c/adsd3500_mode_tbls.h b/drivers/media/i2c/adsd3500_mode_tbls.h
+index 8737e4b9..11f588e5 100644
+--- a/drivers/media/i2c/adsd3500_mode_tbls.h
++++ b/drivers/media/i2c/adsd3500_mode_tbls.h
+@@ -71,6 +71,19 @@ enum {
+ 	ADSD3500_MODE_1024x4096_RAW12_30FPS,
+ 	ADSD3500_MODE_2048x5376_RAW12_30FPS,
+ 	ADSD3500_MODE_2048x3584_RAW12_30FPS,
++	ADSD3500_MODE_3072x1707_30FPS,
++	ADSD3500_MODE_3072x1024_30FPS,
++	ADSD3500_MODE_3072x1366_30FPS,
++	ADSD3500_MODE_2048x1024_30FPS,
++	ADSD3500_MODE_3072x1536_30FPS,
++	ADSD3500_MODE_2048x1792_30FPS,
++	ADSD3500_MODE_1024x3584_30FPS,
++	ADSD3500_MODE_1536x854_30FPS,
++	ADSD3500_MODE_1536x683_30FPS,
++	ADSD3500_MODE_1024x768_30FPS,
++	ADSD3500_MODE_1536x768_30FPS,
++	ADSD3500_MODE_1024x896_30FPS,
++	ADSD3500_MODE_512x1792_30FPS,
+ };
+ 
+ static const int adsd3500_30fps[] = {
+@@ -154,6 +167,23 @@ static const struct camera_common_frmfmt adsd3500_frmfmt[] = {
+ 	{{1024, 4096}, adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x4096_RAW12_30FPS},   // mode66
+ 	{{2048, 5376}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x5376_RAW12_30FPS},   // mode67
+ 	{{2048, 3584}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x3584_RAW12_30FPS},   // mode68
++
++	/* RAW8 modes (69-81) */
++	{{3072, 1707}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1707_30FPS},   	     // mode69
++	{{3072, 1024}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1024_30FPS},         // mode70
++	{{3072, 1366}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1366_30FPS},   	     // mode71
++	{{2048, 1024}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x1024_30FPS},         // mode72
++	{{3072, 1536}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1536_30FPS},         // mode73
++	{{2048, 1792}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x1792_30FPS},         // mode74
++	{{1024, 3584}, adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x3584_30FPS},         // mode75
++	{{1536, 854},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1536x854_30FPS},          // mode76
++	{{1536, 683},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1536x683_30FPS},          // mode77
++	{{1024, 768},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x768_30FPS},          // mode78
++	{{1536, 768},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1536x768_30FPS},          // mode79
++	{{1024, 896},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x896_30FPS},          // mode80
++	{{512, 1792},  adsd3500_30fps, 1, 0, ADSD3500_MODE_512x1792_30FPS},          // mode81
++
++
+ 	/* Add modes with no device tree support after below */
+ };
+ 
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index ba349e4f..41fb9357 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -745,6 +745,100 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.code = MEDIA_BUS_FMT_SRGGB12_1X12,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
++
++	/* --- RAW 8 MEDIA_BUS_FMT_SRGGB8_1X8 --- */
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved and 16BPP AB as SuperFrame */
++		.width = 3072,
++		.height = 1707,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved */
++		.width = 3072,
++		.height = 1024,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved and 8BPP AB as SuperFrame */
++		.width = 3072,
++		.height = 1366,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 12BPP Depth, 4BPP Conf as Interleaved */
++		.width = 2048,
++		.height = 1024,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved and 12BPP AB as SuperFrame */
++		.width = 3072,
++		.height = 1536,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 4BPP Conf as Interleaved and 12BPP AB as SuperFrame */
++		.width = 2048,
++		.height = 1792,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP Depth and AB as Superframe (12BPP + 16BPP / 16BPP + 12BPP) */
++		.width = 1024,
++		.height = 3584,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 16BPP Depth, 8BPP Conf as Interleaved and 16BPP AB as SuperFrame */
++		.width = 1536,
++		.height = 854,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 16BPP Depth, Conf as Interleaved and 16BPP AB as SuperFrame */
++		.width = 1536,
++		.height = 683,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 12BPP Depth, 4BPP Conf as Interleaved and 8BPP AB as SuperFrame */
++		.width = 1024,
++		.height = 768,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 16BPP Depth, 8BPP Conf as Interleaved and 12BPP AB as SuperFrame*/
++		.width = 1536,
++		.height = 768,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 12BPP Depth, 4BPP Conf as Interleaved and 12BPP AB as SuperFrame */
++		.width = 1024,
++		.height = 896,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP Depth and AB as Superframe (12BPP + 16BPP / 16BPP + 12BPP)*/
++		.width = 512,
++		.height = 1792,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++
+ };
+ 
+ static int adsd3500_set_frame_rate(struct adsd3500 *priv, s64 val);
+-- 
+2.25.1
+

--- a/sdcard-images-utils/rpi/patches/linux/0027-drivers-media-i2c-adsd3500-add-RAW8-sensor-modes-sup.patch
+++ b/sdcard-images-utils/rpi/patches/linux/0027-drivers-media-i2c-adsd3500-add-RAW8-sensor-modes-sup.patch
@@ -1,0 +1,128 @@
+From f4c35eae1ba6acfd8cc6f52851918e26f1a46ef3 Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Wed, 20 May 2026 22:13:05 +0530
+Subject: [PATCH] drivers: media: i2c: adsd3500: add RAW8 sensor modes support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Introduce multiple RAW8 (MEDIA_BUS_FMT_SRGGB8_1X8) modes with new
+  resolutions and configurations in adsd3500_mode_tbls and mode info.
+- Extend enum and frame format tables to expose additional sensor
+  operating modes (modes 69–81) at 30 FPS.
+- Update mode info table with corresponding pixel rate and link
+  frequency entries to ensure proper pipeline configuration.
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500.c | 94 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 94 insertions(+)
+
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index 0de0d8d6b179..5cb75be0a50e 100755
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -794,6 +794,100 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+ 
++	/* --- RAW 8 MEDIA_BUS_FMT_SRGGB8_1X8 --- */
++
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved and 16BPP AB as SuperFrame */
++		.width = 3072,
++		.height = 1707,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved */
++		.width = 3072,
++		.height = 1024,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved and 8BPP AB as SuperFrame */
++		.width = 3072,
++		.height = 1366,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 12BPP Depth, 4BPP Conf as Interleaved */
++		.width = 2048,
++		.height = 1024,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 8BPP Conf as Interleaved and 12BPP AB as SuperFrame */
++		.width = 3072,
++		.height = 1536,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP 16BPP Depth, 4BPP Conf as Interleaved and 12BPP AB as SuperFrame */
++		.width = 2048,
++		.height = 1792,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 MP Depth and AB as Superframe (12BPP + 16BPP / 16BPP + 12BPP) */
++		.width = 1024,
++		.height = 3584,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 16BPP Depth, 8BPP Conf as Interleaved and 16BPP AB as SuperFrame */
++		.width = 1536,
++		.height = 854,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 16BPP Depth, Conf as Interleaved and 16BPP AB as SuperFrame */
++		.width = 1536,
++		.height = 683,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 12BPP Depth, 4BPP Conf as Interleaved and 8BPP AB as SuperFrame */
++		.width = 1024,
++		.height = 768,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 16BPP Depth, 8BPP Conf as Interleaved and 12BPP AB as SuperFrame*/
++		.width = 1536,
++		.height = 768,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP 12BPP Depth, 4BPP Conf as Interleaved and 12BPP AB as SuperFrame */
++		.width = 1024,
++		.height = 896,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++	{       /* RAW8 ADSD3100 QMP Depth and AB as Superframe (12BPP + 16BPP / 16BPP + 12BPP)*/
++		.width = 512,
++		.height = 1792,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
++
+ };
+ 
+ static bool adsd3500_regmap_accessible_reg(struct device *dev, unsigned int reg)
+-- 
+2.25.1
+


### PR DESCRIPTION
Expand ADSD3500 driver support by introducing new RAW8 sensor modes
with additional resolutions and configurations, enabling broader use
cases for depth, AB streaming with both interleaved and superframe formats.

Update mode tables, frame formats, and mode info structures to include
modes 69–81 with appropriate media bus formats and pipeline parameters.
Also increase the global MAX_NUM_SENSOR_MODES limit to accommodate the
extended mode set, preventing enumeration issues with larger sensors.
