### PR TITLE
Add RGB camera support from rgb_support branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(WITH_EXAMPLES "Build examples?" ON)
 option(WITH_DOC "Build documentation?" OFF)
 option(WITH_PYTHON "Build python bindings?" ON)
 option(WITH_NETWORK "Build network interface?" OFF)
+option(WITH_RGB_CAMERA "Build with RGB camera support?" OFF)
 set(WITH_PLATFORM "AUTO" CACHE STRING "Platform selection") # Options are: "AUTO", "NVIDIA", "RPI", "WSL2", or "HOST"
 
 ################################# PLATFORM DETECTION ###############################
@@ -167,6 +168,9 @@ if(${ON_TARGET})
                 if (NOT DEFINED LIBTOFI_LIBDIR_PATH)
                         set(LIBTOFI_LIBDIR_PATH "${CMAKE_SOURCE_DIR}/../libs")
                 endif()
+        endif()
+        if (WITH_RGB_CAMERA)
+                add_definitions(-DHAS_RGB_CAMERA)
         endif()
 endif()
 

--- a/examples/bindings/python/rawparser/rawparser.py
+++ b/examples/bindings/python/rawparser/rawparser.py
@@ -106,6 +106,26 @@ def generate_confidence(conf_frame, directory, base_filename, index):
     img = o3d.geometry.Image(norm_conf)
     o3d.io.write_image(safe_join(directory, f'conf_{base_filename}_{index}{PNG_EXT}'), img)
 
+def generate_rgb(rgb_data, directory, base_filename, index, width, height):
+    """Generate RGB JPG from BGR data (SDK already converted from NV12)"""
+    try:
+        # SDK returns BGR format (3 bytes per pixel)
+        if isinstance(rgb_data, np.ndarray):
+            if rgb_data.ndim == 3 and rgb_data.shape == (height, width, 3):
+                bgr_image = rgb_data
+            elif rgb_data.ndim == 2 and rgb_data.shape == (height, width):
+                bgr_image = cv.cvtColor(rgb_data, cv.COLOR_GRAY2BGR)
+            else:
+                bgr_image = rgb_data.reshape((height, width, 3))
+        else:
+            bgr_image = np.array(rgb_data, dtype=np.uint8, copy=False)
+            bgr_image = bgr_image.reshape((height, width, 3))
+        # Save as JPG (OpenCV handles BGR natively)
+        output_path = safe_join(directory, f'rgb_{base_filename}_{index}.jpg')
+        cv.imwrite(output_path, bgr_image, [cv.IMWRITE_JPEG_QUALITY, 95])
+    except Exception as e:
+        print(f"\nWarning: Failed to generate RGB frame {index}: {e}")
+
 def generate_pcloud(xyz_frame, directory, base_filename, index, height, width):
     xyz_frame = xyz_frame.view(np.int16)
     xyz_frame = xyz_frame.reshape(-1, 3)
@@ -251,6 +271,28 @@ def main():
             image_conf = np.reshape(final_conf[frameDataDetails.width*frameDataDetails.height*0:frameDataDetails.width*frameDataDetails.height*1], \
                                     [frameDataDetails.height,frameDataDetails.width])
             generate_confidence(image_conf, frame_dir, base_filename, str_frame_idx)
+
+        # Get the RGB frame
+        if "rgb" in available_types:
+            try:
+                rgb_details = tof.FrameDataDetails()
+                status_rgb = frame.getDataDetails("rgb", rgb_details)
+                if (status_rgb == tof.Status.Ok and rgb_details.width > 0 and
+                        rgb_details.height > 0):
+                    rgb_data = frame.getData("rgb")
+                    rgb_arr = np.array(rgb_data, copy=False)
+                    try:
+                        generate_rgb(
+                            rgb_arr, frame_dir, base_filename, str_frame_idx,
+                            rgb_details.width, rgb_details.height
+                        )
+                        print(f"    Saved RGB JPG")
+                    except Exception as inner_e:
+                        print(f"    Could not extract RGB: {inner_e}")
+                else:
+                    print(f"  - No RGB metadata in frame")
+            except Exception as e:
+                print(f"  Error processing RGB: {e}")
 
         # Get the confidence frame
         if "xyz" in available_types:

--- a/examples/data_collect/main.cpp
+++ b/examples/data_collect/main.cpp
@@ -420,7 +420,18 @@ int main(int argc, char *argv[]) {
             std::chrono::milliseconds(5)); // Sleep for 5ms
     }
 
-    LOG(INFO) << "Capture complete. Frames captured: " << frames_captured;
+    LOG(INFO) << "Waiting for frames to be written...";
+    uint32_t framesWritten = 0;
+    framesWritten = camera->getRecordedFrameCount();
+    int waitCount = 0;
+    while (framesWritten < n_frames && waitCount < 100) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        framesWritten = camera->getRecordedFrameCount();
+        waitCount++;
+    }
+
+    LOG(INFO) << "Capture complete. Frames requested: " << frames_captured
+              << ", Frames written: " << framesWritten;
     status = camera->stopRecording();
     if (status != Status::OK) {
         LOG(WARNING) << "Unable to stop recording!";

--- a/examples/first-frame/main.cpp
+++ b/examples/first-frame/main.cpp
@@ -99,7 +99,7 @@ Status save_frame(aditof::Frame &frame, std::string frameType,
                         std::to_string(mode_num) + ".bin",
                     std::ios::binary);
     frame.getDataDetails(frameType, fDetails);
-    g.write((char *)data1, fDetails.width * fDetails.height * sizeof(uint16_t));
+    g.write((char *)data1, fDetails.bytesCount);
     g.close();
 
     return status;
@@ -256,6 +256,7 @@ int main(int argc, char *argv[]) {
 
     save_frame(frame, "ab", mode);
     save_frame(frame, "depth", mode);
+    save_frame(frame, "rgb", mode);
 
     status = camera->stop();
     if (status != Status::OK) {

--- a/examples/tof-viewer/CMakeLists.txt
+++ b/examples/tof-viewer/CMakeLists.txt
@@ -151,6 +151,17 @@ else()
     )
 endif()
 
+# Add RGB support compile definition if enabled
+if(NOT DEFINED WITH_RGB_CAMERA)
+    set(WITH_RGB_CAMERA OFF)
+endif()
+if(WITH_RGB_CAMERA)
+    target_compile_definitions(ADIToFGUI PRIVATE WITH_RGB_SUPPORT)
+    message(STATUS "RGB camera support enabled in tof-viewer")
+else()
+    message(STATUS "RGB camera support disabled in tof-viewer (original AB-only behavior)")
+endif()
+
 # Link Libraries
 if(UNIX)
 	set(OpenGL_GL_PREFERENCE "LEGACY")

--- a/examples/tof-viewer/include/ADIMainWindow.h
+++ b/examples/tof-viewer/include/ADIMainWindow.h
@@ -478,6 +478,17 @@ class ADIMainWindow {
 		* @brief Displays Point Cloud Window
 		*/
     void DisplayPointCloudWindow(ImGuiWindowFlags overlayFlags);
+#ifdef WITH_RGB_SUPPORT
+    /**
+     * @brief Initialize OpenGL RGB texture
+     */
+    void InitOpenGLRGBTexture();
+
+    /**
+     * @brief Displays RGB Window (separate from AB)
+     */
+    void DisplayRGBWindow(ImGuiWindowFlags overlayFlags);
+#endif
 
     /**
      * @brief print out warning message in popup window if ini param is out of valid range
@@ -660,6 +671,11 @@ class ADIMainWindow {
     uint32_t m_gl_ab_video_texture = 0;
     uint32_t m_gl_depth_video_texture = 0;
     uint32_t m_gl_pointcloud_video_texture = 0;
+#ifdef WITH_RGB_SUPPORT
+    uint32_t m_gl_rgb_video_texture = 0;
+    bool m_set_rgb_win_position_once = true;
+    ImVec2 m_display_rgb_dimensions;
+#endif
     bool m_set_temp_win_position_once = true;
     bool m_set_ab_win_position_once = true;
     bool m_set_depth_win_position_once = true;
@@ -678,6 +694,9 @@ class ADIMainWindow {
     Rect *m_xyz_position;
     Rect *m_ab_position;
     Rect *m_depth_position;
+#ifdef WITH_RGB_SUPPORT
+    Rect *m_rgb_position;
+#endif
     uint32_t m_frame_window_position_state;
     std::shared_ptr<adiviewer::ADIView> m_view_instance = nullptr;
     AppLog m_log;
@@ -713,6 +732,7 @@ class ADIMainWindow {
     bool m_enable_ab_display = true;
     bool m_enable_depth_display = true;
     bool m_enable_xyz_display = true;
+    bool m_enable_rgb_display = true;
 
     std::string m_recording_path = ".";
 };

--- a/examples/tof-viewer/include/ADITypes.h
+++ b/examples/tof-viewer/include/ADITypes.h
@@ -68,6 +68,21 @@ typedef enum {
 	 */
     ADI_IMAGE_FORMAT_AB16,
 
+    /** Image type RGB.
+        *
+        * \details
+        * Each pixel of RGB data is three bytes representing Red, Green, Blue components.
+        * The value of the data represents color information.
+        *
+        * \details
+        * This format represents visible light and is captured by the RGB camera.
+        *
+        * \details
+        * Stride indicates the length of each line in bytes and should be used to determine the start location of each
+        * line of the image in memory.
+        */
+    ADI_IMAGE_FORMAT_RGB,
+
 } ADI_Image_Format_t;
 
 #ifdef __cplusplus

--- a/examples/tof-viewer/include/ADIView.h
+++ b/examples/tof-viewer/include/ADIView.h
@@ -78,7 +78,8 @@ class ADIView {
 		*/
     ADIView(std::shared_ptr<adicontroller::ADIController> ctrl,
             const std::string &name, bool enableAB = true,
-            bool enableDepth = true, bool enableXYZ = true);
+            bool enableDepth = true, bool enableXYZ = true,
+            bool enableRGB = true);
 
     /**
 		* @brief Destructor
@@ -212,6 +213,33 @@ class ADIView {
     int16_t *pointCloud_video_data;
     uint8_t *ab_video_data_8bit;
     uint8_t *depth_video_data_8bit;
+
+#ifdef WITH_RGB_SUPPORT
+    // RGB frame capture related members (following AB/Depth pattern)
+    bool m_rgbFrameAvailable = false;
+    bool m_rgbThreadCreated = false;
+    std::thread m_rgbImageWorker;
+
+    // RGB data buffers (double buffering to prevent flickering)
+    uint8_t *rgb_video_data_rgb = nullptr;      // Front buffer for display
+    uint8_t *rgb_video_data_rgb_back = nullptr; // Back buffer for writing
+    uint8_t *rgb_video_data_8bit = nullptr;     // For OpenGL texture upload
+
+    // RGB synchronization (separate from depth/AB)
+    std::mutex rgb_data_ready_mtx;
+    std::condition_variable rgb_data_ready_cv;
+    bool rgb_data_ready = false;
+
+    // RGB frame parameters
+    static constexpr int RGB_WIDTH = 1920;
+    static constexpr int RGB_HEIGHT = 1200;
+    static constexpr int RGB_FRAME_SIZE = 1358848; // NV12 format: typical size
+
+    // Actual RGB frame dimensions (set dynamically from frame data)
+    int rgbFrameWidth = 0;
+    int rgbFrameHeight = 0;
+#endif // WITH_RGB_SUPPORT
+
     float *normalized_vertices = nullptr;
     size_t pointcloudTableSize = 0;
 
@@ -348,6 +376,13 @@ class ADIView {
     bool ab_data_ready = false;
 
     const size_t N = 50;
+
+#ifdef WITH_RGB_SUPPORT
+    /**
+     * @brief Worker thread function for RGB image capture and conversion
+     */
+    void _displayRgbImage();
+#endif // WITH_RGB_SUPPORT
 
     // Call this before your function
     auto startTimer() { return std::chrono::high_resolution_clock::now(); }

--- a/examples/tof-viewer/src/ADIMainCameraControl.cpp
+++ b/examples/tof-viewer/src/ADIMainCameraControl.cpp
@@ -72,12 +72,13 @@ void ADIMainWindow::InitCamera(std::string filePath) {
     m_enable_ab_display = true;
     m_enable_depth_display = true;
     m_enable_xyz_display = true;
+    m_enable_rgb_display = true;
 
     // Initially create with all displays enabled (will be updated after mode is set)
     m_view_instance = std::make_shared<adiviewer::ADIView>(
         std::make_shared<adicontroller::ADIController>(m_cameras_list),
         "ToFViewer " + version, m_enable_ab_display, m_enable_depth_display,
-        m_enable_xyz_display);
+        m_enable_xyz_display, m_enable_rgb_display);
 
     if (!m_off_line) {
         m_cameras_list.clear();
@@ -158,10 +159,13 @@ void ADIMainWindow::UpdateOfflineFrameTypeAvailability() {
             m_enable_ab_display = (metadata->bitsInAb != 0);
             // XYZ availability is based on xyzEnabled flag in metadata
             m_enable_xyz_display = (metadata->xyzEnabled != 0);
+            // RGB availability is based on frame data type
+            m_enable_rgb_display = frame.haveDataType("rgb");
 
             LOG(INFO) << "Offline frame types available: depth="
                       << m_enable_depth_display << " ab=" << m_enable_ab_display
                       << " xyz=" << m_enable_xyz_display
+                      << " rgb=" << m_enable_rgb_display
                       << " (from metadata: bitsInDepth="
                       << (int)metadata->bitsInDepth
                       << " bitsInAb=" << (int)metadata->bitsInAb
@@ -212,6 +216,31 @@ bool ADIMainWindow::PrepareCamera(uint8_t mode) {
     aditof::CameraDetails camDetails;
     status = GetActiveCamera()->getDetails(camDetails);
     //int32_t totalCaptures = camDetails.frameType.totalCaptures;
+
+    // For live mode, check what frame types are actually available based on config
+    if (!m_off_line) {
+        bool hasDepth = false, hasAB = false, hasXYZ = false, hasRGB = false;
+        for (const auto &detail : camDetails.frameType.dataDetails) {
+            if (detail.type == "depth")
+                hasDepth = true;
+            else if (detail.type == "ab")
+                hasAB = true;
+            else if (detail.type == "xyz")
+                hasXYZ = true;
+            else if (detail.type == "rgb")
+                hasRGB = true;
+        }
+
+        m_enable_depth_display = hasDepth;
+        m_enable_ab_display = hasAB;
+        m_enable_xyz_display = hasXYZ;
+        m_enable_rgb_display = hasRGB;
+
+        LOG(INFO) << "Live mode frame types: depthEnabled=" << (int)hasDepth
+                  << " abEnabled=" << (int)hasAB
+                  << " xyzEnabled=" << (int)hasXYZ
+                  << " rgbEnabled=" << (int)hasRGB;
+    }
 
     // For offline mode, recreate viewer with all frame types enabled
     // The threads will check metadata per-frame to decide if processing is needed
@@ -279,6 +308,9 @@ void ADIMainWindow::CameraPlay(int modeSelect, int viewSelect) {
             InitOpenGLABTexture();
             InitOpenGLDepthTexture();
             InitOpenGLPointCloudTexture();
+#ifdef WITH_RGB_SUPPORT
+            InitOpenGLRGBTexture();
+#endif
 
             if (!m_off_line) {
                 m_view_instance->m_ctrl->StartCapture(m_fps_expected);
@@ -319,13 +351,18 @@ void ADIMainWindow::CameraPlay(int modeSelect, int viewSelect) {
             }
 
             // Check what frame types are available based on metadata config
-            bool haveAB, haveDepth, haveXYZ;
+            bool haveAB, haveDepth, haveXYZ, haveRGB;
             if (m_off_line) {
                 // Offline: use cached availability from UpdateOfflineFrameTypeAvailability()
                 haveAB = m_enable_ab_display && frame->haveDataType("ab");
                 haveDepth =
                     m_enable_depth_display && frame->haveDataType("depth");
                 haveXYZ = m_enable_xyz_display && frame->haveDataType("xyz");
+#ifdef WITH_RGB_SUPPORT
+                haveRGB = frame->haveDataType("rgb");
+#else
+                haveRGB = false;
+#endif
             } else {
                 // Live mode: For AB and XYZ, check config. For depth, always show if data exists
                 // (bitsInDepth may be 0 for ISP-computed depth modes)
@@ -341,11 +378,17 @@ void ADIMainWindow::CameraPlay(int modeSelect, int viewSelect) {
                     haveDepth = frame->haveDataType("depth");
                     haveXYZ = frame->haveDataType("xyz");
                 }
+#ifdef WITH_RGB_SUPPORT
+                haveRGB = frame->haveDataType("rgb");
+#else
+                haveRGB = false;
+#endif
             }
 
             uint32_t numberAvailableDataTypes = 0;
 
-            numberAvailableDataTypes += haveAB ? 1 : 0;
+            // RGB shares the AB window, so count as AB/RGB window (not separate)
+            numberAvailableDataTypes += (haveAB || haveRGB) ? 1 : 0;
             numberAvailableDataTypes += haveDepth ? 1 : 0;
             numberAvailableDataTypes += haveXYZ ? 1 : 0;
 
@@ -428,9 +471,18 @@ void ADIMainWindow::CameraPlay(int modeSelect, int viewSelect) {
             if (haveXYZ) {
                 DisplayPointCloudWindow(overlayFlags);
             }
+#ifdef WITH_RGB_SUPPORT
+            if (haveRGB) {
+                DisplayRGBWindow(overlayFlags);
+            }
             if (haveAB) {
                 DisplayActiveBrightnessWindow(overlayFlags);
             }
+#else
+            if (haveAB) {
+                DisplayActiveBrightnessWindow(overlayFlags);
+            }
+#endif
             if (haveDepth) {
                 DisplayDepthWindow(overlayFlags);
             }

--- a/examples/tof-viewer/src/ADIMainCore.cpp
+++ b/examples/tof-viewer/src/ADIMainCore.cpp
@@ -538,6 +538,15 @@ bool ADIMainWindow::StartImGUI(const ADIViewerArgs &args) {
     m_dict_win_position["fr-sub2"].width = 256.0f;
     m_dict_win_position["fr-sub2"].height = 256.0f;
 
+#ifdef WITH_RGB_SUPPORT
+    // RGB window: 1920x1200 native, scale to 16:10 aspect ratio at ~410px width
+    m_dict_win_position["fr-rgb"].x =
+        WindowCalcX(m_dict_win_position["fr-main"], 10.0f);
+    m_dict_win_position["fr-rgb"].y = m_dict_win_position["fr-main"].y;
+    m_dict_win_position["fr-rgb"].width = 409.6f;
+    m_dict_win_position["fr-rgb"].height = 256.0f; // 16:10 aspect ratio
+#endif
+
     m_dict_win_position["plotA"].x = m_dict_win_position["fr-main"].x;
     m_dict_win_position["plotA"].y =
         WindowCalcY(m_dict_win_position["fr-main"], 10.0f);
@@ -547,6 +556,9 @@ bool ADIMainWindow::StartImGUI(const ADIViewerArgs &args) {
     m_xyz_position = &m_dict_win_position["fr-main"];
     m_ab_position = &m_dict_win_position["fr-sub1"];
     m_depth_position = &m_dict_win_position["fr-sub2"];
+#ifdef WITH_RGB_SUPPORT
+    m_rgb_position = &m_dict_win_position["fr-rgb"];
+#endif
 
     // Setup Dear ImGui style
     //ImGui::StyleColorsDark();

--- a/examples/tof-viewer/src/ADIMainFrames.cpp
+++ b/examples/tof-viewer/src/ADIMainFrames.cpp
@@ -83,6 +83,10 @@ void ADIMainWindow::RenderFrameHoverInfo(ImVec2 hoveredImagePixel,
         imageType = "Depth";
     } else if (format == ADI_Image_Format_t::ADI_IMAGE_FORMAT_AB16) {
         imageType = "AB";
+#ifdef WITH_RGB_SUPPORT
+    } else if (format == ADI_Image_Format_t::ADI_IMAGE_FORMAT_RGB) {
+        imageType = "RGB";
+#endif
     }
 
     if (isHovered || ImGui::IsWindowHovered()) {
@@ -194,6 +198,14 @@ int32_t ADIMainWindow::synchronizeVideo(std::shared_ptr<aditof::Frame> &frame) {
         // AND what data is actually available in the frame
         int32_t activeThreads = 0;
 
+        // Reset all frame availability flags first (they might be stale from previous frame)
+        m_view_instance->m_depthFrameAvailable = false;
+        m_view_instance->m_abFrameAvailable = false;
+        m_view_instance->m_pcFrameAvailable = false;
+#ifdef WITH_RGB_SUPPORT
+        m_view_instance->m_rgbFrameAvailable = false;
+#endif
+
         // Check if depth data is available in the frame
         if (m_view_instance->m_depthThreadCreated &&
             m_view_instance->m_capturedFrame->haveDataType("depth")) {
@@ -214,6 +226,15 @@ int32_t ADIMainWindow::synchronizeVideo(std::shared_ptr<aditof::Frame> &frame) {
             m_view_instance->m_pcFrameAvailable = true;
             activeThreads++;
         }
+
+#ifdef WITH_RGB_SUPPORT
+        // Check if RGB data is available in the frame (only if compiled with RGB support)
+        if (m_view_instance->m_rgbThreadCreated &&
+            m_view_instance->m_capturedFrame->haveDataType("rgb")) {
+            m_view_instance->m_rgbFrameAvailable = true;
+            activeThreads++;
+        }
+#endif // WITH_RGB_SUPPORT
 
         m_view_instance->numOfThreads = activeThreads;
 
@@ -398,6 +419,29 @@ void ADIMainWindow::DisplayActiveBrightnessWindow(
 
         ImGui::SetCursorPos(ImVec2(0, 0));
 
+#ifdef WITH_RGB_SUPPORT
+        // If RGB data is available and processed, show RGB instead of AB
+        if (m_view_instance->rgb_video_data_rgb != nullptr) {
+            glBindTexture(GL_TEXTURE_2D, m_gl_ab_video_texture);
+            // RGB data: stored as BGR (3 bytes per pixel) for OpenGL display
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
+                         m_view_instance->rgbFrameWidth,
+                         m_view_instance->rgbFrameHeight, 0, GL_BGR,
+                         GL_UNSIGNED_BYTE, m_view_instance->rgb_video_data_rgb);
+            glad_glGenerateMipmap(GL_TEXTURE_2D);
+
+            ImVec2 _displayABDimensions = m_display_ab_dimensions;
+
+            if (rotationangledegrees == 90 || rotationangledegrees == 270) {
+                std::swap(_displayABDimensions.x, _displayABDimensions.y);
+            }
+
+            ImageRotated((ImTextureID)m_gl_ab_video_texture,
+                         ImVec2(m_ab_position->width, m_ab_position->height),
+                         ImVec2(_displayABDimensions.x, _displayABDimensions.y),
+                         rotationangleradians);
+        } else
+#endif // WITH_RGB_SUPPORT
         if (m_view_instance->ab_video_data_8bit != nullptr) {
             glBindTexture(GL_TEXTURE_2D, m_gl_ab_video_texture);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_view_instance->frameWidth,
@@ -421,10 +465,20 @@ void ADIMainWindow::DisplayActiveBrightnessWindow(
         GetHoveredImagePix(hoveredImagePixel, ImGui::GetCursorScreenPos(),
                            ImGui::GetIO().MousePos, m_display_ab_dimensions,
                            m_source_depth_image_dimensions);
-        RenderFrameHoverInfo(
-            hoveredImagePixel, m_view_instance->ab_video_data,
-            m_view_instance->frameWidth, ImGui::IsWindowHovered(),
-            ADI_Image_Format_t::ADI_IMAGE_FORMAT_AB16, "Intensity");
+#ifdef WITH_RGB_SUPPORT
+        if (m_view_instance->rgb_video_data_rgb != nullptr) {
+            RenderFrameHoverInfo(
+                hoveredImagePixel, nullptr, m_view_instance->rgbFrameWidth,
+                ImGui::IsWindowHovered(),
+                ADI_Image_Format_t::ADI_IMAGE_FORMAT_RGB, "RGB Pixel");
+        } else
+#endif // WITH_RGB_SUPPORT
+        {
+            RenderFrameHoverInfo(
+                hoveredImagePixel, m_view_instance->ab_video_data,
+                m_view_instance->frameWidth, ImGui::IsWindowHovered(),
+                ADI_Image_Format_t::ADI_IMAGE_FORMAT_AB16, "Intensity");
+        }
     }
 
     ImGui::End();
@@ -1116,3 +1170,88 @@ void ADIMainWindow::MatrixMultiply(mat4x4 out, mat4x4 a, mat4x4 b) {
     mat4x4_dup(btmp, b);
     mat4x4_mul(out, a, b);
 }
+
+#ifdef WITH_RGB_SUPPORT
+//*******************************************
+//* Section: Handling of RGB Window
+//*******************************************
+
+void ADIMainWindow::InitOpenGLRGBTexture() {
+    GLuint rgb_texture;
+    glGenTextures(1, &rgb_texture);
+    glBindTexture(GL_TEXTURE_2D, rgb_texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    m_gl_rgb_video_texture = rgb_texture;
+}
+
+void ADIMainWindow::DisplayRGBWindow(ImGuiWindowFlags overlayFlags) {
+    ImVec2 size;
+
+    if (m_view_instance->rgbFrameWidth > 0 &&
+        m_view_instance->rgbFrameHeight > 0) {
+        float autoscale = std::fmin(
+            (m_rgb_position->width / m_view_instance->rgbFrameWidth),
+            (m_rgb_position->height / m_view_instance->rgbFrameHeight));
+
+        size.x = m_view_instance->rgbFrameWidth * autoscale * m_dpi_scale_factor;
+        size.y = m_view_instance->rgbFrameHeight * autoscale * m_dpi_scale_factor;
+
+        if (rotationangledegrees == 90 || rotationangledegrees == 270) {
+            std::swap(size.x, size.y);
+        }
+
+        m_display_rgb_dimensions = {static_cast<float>(size.x),
+                                    static_cast<float>(size.y)};
+        size.x /= m_dpi_scale_factor;
+        size.y /= m_dpi_scale_factor;
+    }
+
+    SetWindowPosition(m_rgb_position->x, m_rgb_position->y);
+    SetWindowSize(m_rgb_position->width, m_rgb_position->height);
+
+    if (ImGui::Begin("RGB Window", nullptr,
+                     overlayFlags | ImGuiWindowFlags_NoTitleBar)) {
+
+        ImGui::SetCursorPos(ImVec2(0, 0));
+
+        if (m_view_instance->rgb_video_data_8bit != nullptr &&
+            m_view_instance->rgbFrameWidth > 0 &&
+            m_view_instance->rgbFrameHeight > 0) {
+
+            uint8_t *rgb_buffer_ptr = nullptr;
+            int rgb_width = 0, rgb_height = 0;
+            {
+                std::lock_guard<std::mutex> rgb_lock(
+                    m_view_instance->rgb_data_ready_mtx);
+                rgb_buffer_ptr = m_view_instance->rgb_video_data_8bit;
+                rgb_width = m_view_instance->rgbFrameWidth;
+                rgb_height = m_view_instance->rgbFrameHeight;
+            }
+
+            if (rgb_buffer_ptr != nullptr && rgb_width > 0 && rgb_height > 0) {
+                glBindTexture(GL_TEXTURE_2D, m_gl_rgb_video_texture);
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, rgb_width, rgb_height, 0,
+                             GL_BGR, GL_UNSIGNED_BYTE, rgb_buffer_ptr);
+                glad_glGenerateMipmap(GL_TEXTURE_2D);
+
+                ImVec2 _displayRGBDimensions = m_display_rgb_dimensions;
+
+                if (rotationangledegrees == 90 || rotationangledegrees == 270) {
+                    std::swap(_displayRGBDimensions.x, _displayRGBDimensions.y);
+                }
+
+                ImageRotated(
+                    (ImTextureID)m_gl_rgb_video_texture,
+                    ImVec2(m_rgb_position->width, m_rgb_position->height),
+                    ImVec2(_displayRGBDimensions.x, _displayRGBDimensions.y),
+                    rotationangleradians);
+            }
+        }
+    }
+
+    ImGui::End();
+}
+#endif // WITH_RGB_SUPPORT

--- a/examples/tof-viewer/src/ADIView.cpp
+++ b/examples/tof-viewer/src/ADIView.cpp
@@ -66,7 +66,8 @@ using namespace adiviewer;
 using namespace adicontroller;
 
 ADIView::ADIView(std::shared_ptr<ADIController> ctrl, const std::string &name,
-                 bool enableAB, bool enableDepth, bool enableXYZ)
+                 bool enableAB, bool enableDepth, bool enableXYZ,
+                 bool enableRGB)
     : m_ctrl(ctrl), m_viewName(name), m_distanceVal(0), m_smallSignal(false),
       m_crtSmallSignalState(false) {
 
@@ -143,6 +144,19 @@ ADIView::ADIView(std::shared_ptr<ADIController> ctrl, const std::string &name,
     } else {
         LOG(INFO) << "Point cloud processing disabled by config (xyzEnable=0)";
     }
+
+#ifdef WITH_RGB_SUPPORT
+    // Conditionally create RGB worker thread based on config
+    if (enableRGB) {
+        m_rgbThreadCreated = true;
+        m_rgbImageWorker =
+            std::thread(std::bind(&ADIView::_displayRgbImage, this));
+        LOG(INFO) << "RGB capture thread created (will process frames "
+                     "containing RGB data)";
+    } else {
+        LOG(INFO) << "RGB processing disabled by config (rgbCameraEnable=0)";
+    }
+#endif // WITH_RGB_SUPPORT
 }
 
 ADIView::~ADIView() {
@@ -166,6 +180,14 @@ ADIView::~ADIView() {
         m_pointCloudImageWorker.join();
     }
 
+#ifdef WITH_RGB_SUPPORT
+    // Join RGB worker thread (only if enabled at build time)
+    if (m_rgbThreadCreated && m_rgbImageWorker.joinable()) {
+        m_rgbImageWorker.join();
+        LOG(INFO) << "RGB worker thread joined successfully";
+    }
+#endif // WITH_RGB_SUPPORT
+
     vertexArraySize = 0;
     m_capturedFrame = nullptr;
 
@@ -187,6 +209,21 @@ void ADIView::cleanUp() {
         delete[] normalized_vertices;
         normalized_vertices = nullptr;
     }
+
+#ifdef WITH_RGB_SUPPORT
+    if (rgb_video_data_rgb != nullptr) {
+        delete[] rgb_video_data_rgb;
+        rgb_video_data_rgb = nullptr;
+    }
+    if (rgb_video_data_rgb_back != nullptr) {
+        delete[] rgb_video_data_rgb_back;
+        rgb_video_data_rgb_back = nullptr;
+    }
+    if (rgb_video_data_8bit != nullptr) {
+        delete[] rgb_video_data_8bit;
+        rgb_video_data_8bit = nullptr;
+    }
+#endif
 }
 
 void ADIView::setABMaxRange(std::string value) {
@@ -1230,3 +1267,113 @@ void ADIView::startCamera() {
 
 // ARM NEON implementations are in ADIView_neon.cpp (compiled separately)
 // CUDA implementations are in ADIView_cuda_wrapper.cpp and ADIView_cuda.cu (compiled separately)
+
+#ifdef WITH_RGB_SUPPORT
+
+/**
+ * @brief Worker thread for RGB image capture and conversion
+ *
+ * Synchronization Pattern (Two-Phase Locking):
+ * Phase 1: Acquire m_frameCapturedMutex, check m_rgbFrameAvailable, release lock
+ * Phase 2: Process RGB data without lock (safe because main thread blocks on barrier)
+ * Phase 3: Participate in barrier via m_waitKeyBarrier counter
+ */
+void ADIView::_displayRgbImage() {
+    while (!m_stopWorkersFlag) {
+        // ============================================================
+        // PHASE 1: Wait for new frame (SHORT LOCK)
+        // ============================================================
+        {
+            std::unique_lock<std::mutex> lock(m_frameCapturedMutex);
+            m_frameCapturedCv.wait(lock, [&]() {
+                return m_rgbFrameAvailable || m_stopWorkersFlag;
+            });
+
+            if (m_stopWorkersFlag) {
+                break;
+            }
+
+            m_rgbFrameAvailable = false;
+
+            if (m_capturedFrame == nullptr) {
+                continue;
+            }
+
+            lock.unlock();
+        }
+
+        // ============================================================
+        // PHASE 2: Process RGB data (NO LOCK)
+        // ============================================================
+        try {
+            uint8_t *bgr_data = nullptr;
+            auto status =
+                m_capturedFrame->getData("rgb", (uint16_t **)&bgr_data);
+
+            if (status != aditof::Status::OK || bgr_data == nullptr) {
+                continue;
+            }
+
+            aditof::FrameDataDetails frameRgbDetails;
+            m_capturedFrame->getDataDetails("rgb", frameRgbDetails);
+
+            int frameHeight = static_cast<int>(frameRgbDetails.height);
+            int frameWidth = static_cast<int>(frameRgbDetails.width);
+
+            if (frameHeight <= 0 || frameWidth <= 0) {
+                continue;
+            }
+
+            rgbFrameWidth = frameWidth;
+            rgbFrameHeight = frameHeight;
+
+            if (rgb_video_data_rgb == nullptr) {
+                size_t bgr_buffer_size = frameHeight * frameWidth * 3;
+                rgb_video_data_rgb = new uint8_t[bgr_buffer_size];
+                rgb_video_data_rgb_back = new uint8_t[bgr_buffer_size];
+                rgb_video_data_8bit = new uint8_t[bgr_buffer_size];
+                if (rgb_video_data_rgb == nullptr ||
+                    rgb_video_data_rgb_back == nullptr ||
+                    rgb_video_data_8bit == nullptr) {
+                    LOG(ERROR) << "RGB worker: Failed to allocate RGB buffers";
+                    continue;
+                }
+                LOG(INFO) << "RGB buffers allocated: " << frameWidth << "x"
+                          << frameHeight;
+            }
+
+            size_t bgr_size = frameHeight * frameWidth * 3;
+            std::memcpy(rgb_video_data_rgb_back, bgr_data, bgr_size);
+
+            {
+                std::lock_guard<std::mutex> data_lock(rgb_data_ready_mtx);
+                std::swap(rgb_video_data_rgb, rgb_video_data_rgb_back);
+                std::memcpy(rgb_video_data_8bit, rgb_video_data_rgb, bgr_size);
+                rgb_data_ready = true;
+            }
+            rgb_data_ready_cv.notify_one();
+
+        } catch (const std::exception &e) {
+            continue;
+        }
+
+        // ============================================================
+        // PHASE 3: Barrier synchronization
+        // ============================================================
+        {
+            std::unique_lock<std::mutex> imshow_lock(m_imshowMutex);
+            m_waitKeyBarrier++;
+            if (m_waitKeyBarrier == numOfThreads) {
+                imshow_lock.unlock();
+                m_barrierCv.notify_one();
+            }
+        }
+    }
+
+    if (rgb_video_data_rgb != nullptr) {
+        delete[] rgb_video_data_rgb;
+        rgb_video_data_rgb = nullptr;
+    }
+}
+
+#endif // WITH_RGB_SUPPORT


### PR DESCRIPTION
CMakeLists.txt:
- Add WITH_RGB_CAMERA build option (default OFF)
- Add HAS_RGB_CAMERA preprocessor define when enabled (ON_TARGET only)

examples/tof-viewer/CMakeLists.txt:
- Add WITH_RGB_SUPPORT compile definition guard for ADIToFGUI

examples/tof-viewer/include/ADITypes.h:
- Add ADI_IMAGE_FORMAT_RGB enum value

examples/tof-viewer/include/ADIView.h:
- Add RGB worker thread, double-buffer members, sync primitives (WITH_RGB_SUPPORT guard)
- Add _displayRgbImage() worker method declaration
- Add enableRGB parameter to constructor

examples/tof-viewer/include/ADIMainWindow.h:
- Add m_gl_rgb_video_texture, m_display_rgb_dimensions, m_rgb_position members
- Add InitOpenGLRGBTexture() and DisplayRGBWindow() method declarations
- Add m_enable_rgb_display flag

examples/tof-viewer/src/ADIView.cpp:
- Add enableRGB constructor parameter, create RGB worker thread conditionally
- Join and cleanup RGB worker thread in destructor
- Implement _displayRgbImage() two-phase locking worker

examples/tof-viewer/src/ADIMainCameraControl.cpp:
- Initialize m_enable_rgb_display, pass to ADIView constructor
- Detect rgb frame type availability (offline + live modes)
- Add haveRGB flag, InitOpenGLRGBTexture() call, DisplayRGBWindow() call

examples/tof-viewer/src/ADIMainCore.cpp:
- Add fr-rgb window position layout, assign m_rgb_position

examples/tof-viewer/src/ADIMainFrames.cpp:
- Reset m_rgbFrameAvailable per frame, count RGB thread in activeThreads
- Render RGB in AB window when available; show AB otherwise
- RGB hover info support
- Add InitOpenGLRGBTexture() and DisplayRGBWindow() implementations

examples/first-frame/main.cpp:
- Call save_frame(frame, "rgb", mode)
- Use fDetails.bytesCount for correct binary output size

examples/data_collect/main.cpp:
- Wait for all requested frames to be written before stopping recording

examples/bindings/python/rawparser/rawparser.py:
- Add generate_rgb() function for BGR frame extraction
- Extract and save RGB frames when available in recorded data