### PR TITLE
fix: reset frame loss counter and frame number tracking on stream restart

### DIFF
--- a/examples/tof-viewer/src/ADIController.cpp
+++ b/examples/tof-viewer/src/ADIController.cpp
@@ -73,6 +73,8 @@ void ADIController::StartCapture(const uint32_t frameRate) {
     m_frame_counter = 0;
     m_stopFlag = false;
     m_frames_lost = 0;
+    m_prev_frame_number = static_cast<uint32_t>(-1);
+    m_current_frame_number = 0;
     m_frame_history.clear();
     m_workerThread = std::thread([this]() { captureFrames(); });
 }


### PR DESCRIPTION
Reset m_prev_frame_number to sentinel (-1) and m_current_frame_number to 0 in StartCapture() so the first-frame guard fires correctly on restart. Without this, the gap between the last ISP frame number of the previous session and the first of the new session was incorrectly counted as frame loss.