### PR TITLE
fix: normalize depth colormap to fixed 16-bit range in pygame example

### DIFF
--- a/examples/bindings/python/streaming/depth-image-animation-pygame.py
+++ b/examples/bindings/python/streaming/depth-image-animation-pygame.py
@@ -106,7 +106,8 @@ modeDetails = tof.DepthSensorModeDetails()
 status = sensor.getModeDetails(int(mode),modeDetails)
     
 def normalize(image_scalar, width, height):
-    image_scalar_norm = image_scalar / image_scalar.max()
+    # Normalize to fixed 16-bit range so colormap is consistent across frames
+    image_scalar_norm = np.clip(image_scalar / 65535.0, 0.0, 1.0)
 
     # Apply the colormap to the scalar image to obtain an RGB image
     image_rgb = jet_colormap(image_scalar_norm)


### PR DESCRIPTION
Replace per-frame dynamic normalization (/ image_scalar.max()) with a fixed 65535.0 divisor so the jet colormap mapping is consistent across frames. The old approach caused colors to shift on every frame whenever the scene max depth changed.