### PR TITLE
adsd3500: register 1024x3072 RAW8 V4L2 mode across Nvidia and RPi platforms

### DIFF
--- a/sdcard-images-utils/nvidia/patches/hardware/nvidia/t23x/nv-public/0023-overlay-dual_adsd3500-Add-1024x3072-RAW8-resolution-.patch
+++ b/sdcard-images-utils/nvidia/patches/hardware/nvidia/t23x/nv-public/0023-overlay-dual_adsd3500-Add-1024x3072-RAW8-resolution-.patch
@@ -1,0 +1,151 @@
+From e953b49b34b36494784e89c896658b28fb8e1062 Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 29 Jun 2026 16:16:13 +0530
+Subject: [PATCH] overlay: dual_adsd3500: Add 1024x3072 RAW8 resolution as
+ mode82 in DTS files
+
+Add mode82 (1024x3072, RAW8, 8-bit DPHY) to the below camera device tree
+overlays for the ADSD3500 on Tegra234/P3767:
+- tegra234-p3767-camera-p3768-adsd3500.dts (serial_b)
+- tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts (serial_c)
+- tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts (serial_c)
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ .../tegra234-p3767-camera-p3768-adsd3500.dts  | 32 +++++++++++++++++++
+ ...-dual-adsd3500-adsd3100-arducam-ar0234.dts | 32 +++++++++++++++++++
+ ...67-camera-p3768-dual-adsd3500-adsd3100.dts | 32 +++++++++++++++++++
+ 3 files changed, 96 insertions(+)
+
+diff --git a/overlay/tegra234-p3767-camera-p3768-adsd3500.dts b/overlay/tegra234-p3767-camera-p3768-adsd3500.dts
+index 225fcc8..eeafd93 100644
+--- a/overlay/tegra234-p3767-camera-p3768-adsd3500.dts
++++ b/overlay/tegra234-p3767-camera-p3768-adsd3500.dts
+@@ -2919,6 +2919,38 @@
+ 							max_exp_time = "660000";
+ 							embedded_metadata_height = "1";
+ 						};
++						mode82 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_b";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "3072";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
+ 						ports {
+ 							#address-cells = <1>;
+ 							#size-cells = <0>;
+diff --git a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts
+index af5f098..b6e0b65 100644
+--- a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts
++++ b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100-arducam-ar0234.dts
+@@ -3151,6 +3151,38 @@
+ 								max_exp_time = "660000";
+ 								embedded_metadata_height = "1";
+ 							};
++							mode82 {
++								mclk_khz = "104250";
++								num_lanes = "2";
++								tegra_sinterface = "serial_c";
++								phy_mode = "DPHY";
++								discontinuous_clk = "yes";
++								dpcm_enable = "false";
++								cil_settletime = "0";
++								dynamic_pixel_bit_depth = "8";
++								csi_pixel_bit_depth = "8";
++								mode_type = "bayer";
++								pixel_phase = "rggb";
++
++								active_w = "1024";
++								active_h = "3072";
++								readout_orientation = "0";
++								line_length = "1024";
++								inherent_gain = "1";
++								mclk_multiplier = "4";
++								pix_clk_hz = "625000000";
++
++								min_gain_val = "0";
++								max_gain_val = "48";
++								gain_step_pitch = "0.3";
++								min_hdr_ratio = "1";
++								max_hdr_ratio = "1";
++								min_framerate = "1.5";
++								max_framerate = "30";
++								min_exp_time = "30";
++								max_exp_time = "660000";
++								embedded_metadata_height = "1";
++							};
+ 							ports {
+ 								#address-cells = <1>;
+ 								#size-cells = <0>;
+diff --git a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+index dd1c0be..8978c8c 100644
+--- a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
++++ b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+@@ -2855,6 +2855,38 @@
+ 							max_exp_time = "660000";
+ 							embedded_metadata_height = "1";
+ 						};
++						mode82 {
++							mclk_khz = "104250";
++							num_lanes = "2";
++							tegra_sinterface = "serial_c";
++							phy_mode = "DPHY";
++							discontinuous_clk = "yes";
++							dpcm_enable = "false";
++							cil_settletime = "0";
++							dynamic_pixel_bit_depth = "8";
++							csi_pixel_bit_depth = "8";
++							mode_type = "bayer";
++							pixel_phase = "rggb";
++
++							active_w = "1024";
++							active_h = "3072";
++							readout_orientation = "0";
++							line_length = "1024";
++							inherent_gain = "1";
++							mclk_multiplier = "4";
++							pix_clk_hz = "625000000";
++
++							min_gain_val = "0";
++							max_gain_val = "48";
++							gain_step_pitch = "0.3";
++							min_hdr_ratio = "1";
++							max_hdr_ratio = "1";
++							min_framerate = "1.5";
++							max_framerate = "30";
++							min_exp_time = "30";
++							max_exp_time = "660000";
++							embedded_metadata_height = "1";
++						};
+ 						ports {
+ 							#address-cells = <1>;
+ 							#size-cells = <0>;
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0027-media-i2c-nv_adsd3500-Add-1024x3072-RAW8-resolution-.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0027-media-i2c-nv_adsd3500-Add-1024x3072-RAW8-resolution-.patch
@@ -1,0 +1,66 @@
+From 48cd7a4ebe35ada3921ffd7fccf8107271f0cef7 Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 29 Jun 2026 16:20:35 +0530
+Subject: [PATCH] media: i2c: nv_adsd3500: Add 1024x3072 RAW8 resolution as
+ mode82
+
+Add ADSD3500_MODE_1024x3072_30FPS (mode82) to the mode enum and
+adsd3500_frmfmt table in adsd3500_mode_tbls.h, and add the
+corresponding mode_info entry in nv_adsd3500.c.
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500_mode_tbls.h | 4 +++-
+ drivers/media/i2c/nv_adsd3500.c        | 7 +++++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/adsd3500_mode_tbls.h b/drivers/media/i2c/adsd3500_mode_tbls.h
+index 11f588e5..d65063de 100644
+--- a/drivers/media/i2c/adsd3500_mode_tbls.h
++++ b/drivers/media/i2c/adsd3500_mode_tbls.h
+@@ -84,6 +84,7 @@ enum {
+ 	ADSD3500_MODE_1536x768_30FPS,
+ 	ADSD3500_MODE_1024x896_30FPS,
+ 	ADSD3500_MODE_512x1792_30FPS,
++	ADSD3500_MODE_1024x3072_30FPS,
+ };
+ 
+ static const int adsd3500_30fps[] = {
+@@ -168,7 +169,7 @@ static const struct camera_common_frmfmt adsd3500_frmfmt[] = {
+ 	{{2048, 5376}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x5376_RAW12_30FPS},   // mode67
+ 	{{2048, 3584}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x3584_RAW12_30FPS},   // mode68
+ 
+-	/* RAW8 modes (69-81) */
++	/* RAW8 modes (69-82) */
+ 	{{3072, 1707}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1707_30FPS},   	     // mode69
+ 	{{3072, 1024}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1024_30FPS},         // mode70
+ 	{{3072, 1366}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1366_30FPS},   	     // mode71
+@@ -182,6 +183,7 @@ static const struct camera_common_frmfmt adsd3500_frmfmt[] = {
+ 	{{1536, 768},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1536x768_30FPS},          // mode79
+ 	{{1024, 896},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x896_30FPS},          // mode80
+ 	{{512, 1792},  adsd3500_30fps, 1, 0, ADSD3500_MODE_512x1792_30FPS},          // mode81
++	{{1024, 3072}, adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x3072_30FPS},         // mode82
+ 
+ 
+ 	/* Add modes with no device tree support after below */
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index 41fb9357..8e9d67e1 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -838,6 +838,13 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
+ 		.link_freq_idx = 0
+ 	},
++	{       /* RAW8 ADSD3100 MP */
++		.width = 1024,
++		.height = 3072,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
+ 
+ };
+ 
+-- 
+2.25.1
+

--- a/sdcard-images-utils/rpi/patches/linux/0028-drivers-media-i2c-adsd3500-add-RAW8-1024x3072.patch
+++ b/sdcard-images-utils/rpi/patches/linux/0028-drivers-media-i2c-adsd3500-add-RAW8-1024x3072.patch
@@ -1,0 +1,31 @@
+From 38f85d106e6b4e3ca62fec04dc79e12e28ee1e17 Mon Sep 17 00:00:00 2001
+From: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 29 Jun 2026 18:52:07 +0530
+Subject: [PATCH] drivers: media: i2c: adsd3500: add RAW8 1024x3072
+
+Signed-off-by: Sivasubramanaiyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index 5cb75be0a50e..f54edada3b1d 100755
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -887,6 +887,13 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
+ 		.link_freq_idx = 0
+ 	},
++	{       /* RAW8 ADSD3100 MP */
++		.width = 1024,
++		.height = 3072,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
++		.link_freq_idx = 0
++	},
+ 
+ };
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Summary
Adds support for a new RAW8 resolution — 1024×3072 at 30 FPS — to the ADSD3500 kernel driver patches for both the NVIDIA Jetson and Raspberry Pi SD card image builds. This exposes the new resolution to V4L2 as mode 82 (ADSD3500_MODE_1024x3072_30FPS).