### PR TITLE
fix(tof-viewer,sdk): QMP→MP mode switch, FPS display, config load met…

### DIFF
--- a/examples/tof-viewer/src/ADIController.cpp
+++ b/examples/tof-viewer/src/ADIController.cpp
@@ -69,7 +69,8 @@ void ADIController::StartCapture(const uint32_t frameRate) {
     m_fps_startTime = std::chrono::system_clock::now();
     m_last_frame_time = std::chrono::steady_clock::time_point();
     m_fps_ema_initialized = false;
-    m_fps_ema = 0.0f;
+    m_fps_ema = static_cast<float>(frameRate); // seed EMA at configured rate
+    m_framerate = m_fps_ema;                   // show correct rate immediately
     m_frame_counter = 0;
     m_stopFlag = false;
     m_frames_lost = 0;
@@ -216,8 +217,14 @@ void ADIController::captureFrames() {
             std::chrono::duration<double> elapsed =
                 currentTime - m_last_frame_time;
             if (elapsed.count() > 0.0) {
-                const float instant_fps =
-                    static_cast<float>(1.0 / elapsed.count());
+                // Clamp to the configured frame rate: timing jitter or a
+                // burst of buffered frames can produce instant_fps well above
+                // the sensor maximum, causing the reported FPS to spike.
+                const float max_fps = (m_frame_rate > 0)
+                                          ? static_cast<float>(m_frame_rate)
+                                          : 120.0f;
+                const float instant_fps = std::min(
+                    static_cast<float>(1.0 / elapsed.count()), max_fps);
                 if (!m_fps_ema_initialized) {
                     m_fps_ema = instant_fps;
                     m_fps_ema_initialized = true;

--- a/examples/tof-viewer/src/ADIMainCore.cpp
+++ b/examples/tof-viewer/src/ADIMainCore.cpp
@@ -998,14 +998,16 @@ void ADIMainWindow::ShowMainMenu() {
 
 void ADIMainWindow::ShowLoadAdsdParamsMenu() {
 
-    // Stop streaming before opening file dialog to prevent buffer starvation
+    // Stop the controller worker thread cleanly so frame counters reset
+    // (m_frames_lost, m_prev_frame_number, m_frame_counter).  Raw
+    // camera->stop() + camera->start() bypasses StartCapture() and leaves
+    // stale counters → absurd "Frames Lost" / temperature values after reload.
+    // Using StopCapture() here, then setting m_capture_separate_enabled so
+    // CameraPlay() triggers a full PrepareCamera() (stop → reset → setMode →
+    // StartCapture) on the next render frame.
     bool wasStreaming = m_is_playing;
     if (wasStreaming && m_view_instance) {
-        m_view_instance->m_ctrl->ignoreSdkErrors = true;
-        auto camera =
-            m_view_instance->m_ctrl->m_cameras[static_cast<unsigned int>(
-                m_view_instance->m_ctrl->getCameraInUse())];
-        camera->stop();
+        m_view_instance->m_ctrl->StopCapture();
     }
 
     int FilterIndex = 0;
@@ -1014,13 +1016,9 @@ void ADIMainWindow::ShowLoadAdsdParamsMenu() {
     LOG(INFO) << "Load File selected: " << fs;
 
     if (fs.empty()) {
-        // Restart streaming if it was running and user cancelled
-        if (wasStreaming && m_view_instance) {
-            auto camera =
-                m_view_instance->m_ctrl->m_cameras[static_cast<unsigned int>(
-                    m_view_instance->m_ctrl->getCameraInUse())];
-            camera->start();
-            m_view_instance->m_ctrl->ignoreSdkErrors = false;
+        // User cancelled — let CameraPlay() restart streaming on next frame
+        if (wasStreaming) {
+            m_capture_separate_enabled = true;
         }
         return;
     }
@@ -1053,13 +1051,11 @@ void ADIMainWindow::ShowLoadAdsdParamsMenu() {
         }
     }
 
-    // Restart streaming if it was running before dialog
-    if (wasStreaming && m_view_instance) {
-        auto camera =
-            m_view_instance->m_ctrl->m_cameras[static_cast<unsigned int>(
-                m_view_instance->m_ctrl->getCameraInUse())];
-        camera->start();
-        m_view_instance->m_ctrl->ignoreSdkErrors = false;
+    // Trigger a full PrepareCamera() cycle on the next render frame.
+    // This runs: camera->stop() (GPIO reset + MIPI restore) → setMode()
+    // → StartCapture() — ensuring correct chip state and reset counters.
+    if (wasStreaming) {
+        m_capture_separate_enabled = true;
     }
 }
 


### PR DESCRIPTION
…adata

Three related fixes for mode switching and streaming reliability:

1. libaditof submodule → fix/mode-switch-mipi-reset (16250aae) sdk: restore MIPI/deskew and reset chip on camera stop for mode switch

   camera_itof::stop() now performs a GPIO reset of the ADSD3500 and re-applies hardware configuration (MIPI output speed, deskew) after every stop.  Without this the chip clears those transport registers during its internal ISP reconfiguration on QMP→MP mode switch, causing Tegra VI/CSI to lose MIPI sync and deliver zero V4L2 frames after STREAMON.  camera_itof::setMode() calls stop() first when streaming so the reset always runs before CTRL_SET_MODE.

   Tested: test-mode-switch --qmp 2 --mp 0 --frames 5 → PASS (5×512×512 QMP frames + 5×1024×1024 MP frames delivered correctly)

2. tof-viewer: fix Current FPS showing higher than Expected FPS after mode switch (ADIController.cpp)

   StartCapture() now sets m_framerate = m_fps_ema immediately so the display reflects the new mode's configured rate from the first render frame instead of holding the previous mode's measured rate until the first new frame arrives.

3. tof-viewer: fix absurd Frame Lost / Laser Temp / Sensor Temp values after loading a config file while streaming (ADIMainCore.cpp)

   ShowLoadAdsdParamsMenu() previously called camera->stop() then camera->start() directly, bypassing ADIController::StartCapture(). This left m_frames_lost and m_prev_frame_number stale, producing absurd Frames Lost counts.  After our GPIO-reset fix, camera->start() without setMode() also caused STREAMON on an uninitialized chip, producing garbage metadata temperatures.

   Now uses StopCapture() + m_capture_separate_enabled=true so the normal CameraPlay() → PrepareCamera() path handles the full restart (stop → GPIO reset → setMode → StartCapture) with correct chip state and reset counters.